### PR TITLE
Allow calling mark() functions when not tracing

### DIFF
--- a/src/etwtrace/__init__.py
+++ b/src/etwtrace/__init__.py
@@ -169,6 +169,11 @@ def enable_if(enable_var, type_var):
     tracer.enable()
 
 
+def is_active():
+    """Returns True if tracing is active."""
+    return bool(_tracer)
+
+
 def mark(name):
     """Emits a mark event with the provided text."""
     if _tracer:

--- a/tests/test_etw.py
+++ b/tests/test_etw.py
@@ -234,6 +234,10 @@ def test_but_do_we_instrument():
     )
 
 
+def test_but_are_we_inactive():
+    assert etwtrace.is_active() is False
+
+
 def test_but_do_we_warn_on_mark():
     with pytest.warns(RuntimeWarning):
         etwtrace.mark("Test mark without tracing")


### PR DESCRIPTION
This allows code to use them unconditionally, and only have to deal with a warning if tracing is not activated.
Adds is_active() function to allow for testing tracing state.
Fixes #17